### PR TITLE
Either show text or html in Popup

### DIFF
--- a/src/ui/mails/Mails.js
+++ b/src/ui/mails/Mails.js
@@ -174,9 +174,9 @@ class Mails extends React.Component {
                   {cellData.value.template_id
                     ? <a onClick={() => setCurrentEmail(cellData.value)}><b>Show template</b></a>
                     : <span>
-                        <a onClick={() => setCurrentEmail(cellData.value, 'text/plain')}><b>Show plain text email</b></a>&nbsp;|&nbsp;
-                        <a onClick={() => setCurrentEmail(cellData.value, 'text/html')}><b>Show html email</b></a>&nbsp;<br />
-                      </span>
+                      <a onClick={() => setCurrentEmail(cellData.value, 'text/plain')}><b>Show plain text email</b></a>&nbsp;|&nbsp;
+                      <a onClick={() => setCurrentEmail(cellData.value, 'text/html')}><b>Show html email</b></a>&nbsp;<br />
+                    </span>
                   }
                 </div>
               )

--- a/src/ui/mails/Mails.js
+++ b/src/ui/mails/Mails.js
@@ -112,7 +112,7 @@ class Mails extends React.Component {
         <a href='#' onClick={this.refresh}>Refresh</a>
       </div>
 
-      {currentEmail ? <PopUp currentEmail={currentEmail} hide={hide} selectedEmailType={selectedEmailType} /> : null}
+      {currentEmail ? <PopUp currentEmail={currentEmail} selectedEmailType={selectedEmailType} hide={hide}/> : null}
 
       <ReactTable
         style={{ marginTop: '12px' }}
@@ -171,8 +171,13 @@ class Mails extends React.Component {
               accessor: mail => mail,
               Cell: cellData => (
                 <div>
-                  <a onClick={() => setCurrentEmail(cellData.value, 'text/plain')}><b>Show plain text email</b></a>&nbsp;|&nbsp;
-                  <a onClick={() => setCurrentEmail(cellData.value, 'text/html')}><b>Show html email</b></a>&nbsp;<br />
+                  {cellData.value.template_id
+                    ? <a onClick={() => setCurrentEmail(cellData.value)}><b>Show template</b></a>
+                    : <span>
+                        <a onClick={() => setCurrentEmail(cellData.value, 'text/plain')}><b>Show plain text email</b></a>&nbsp;|&nbsp;
+                        <a onClick={() => setCurrentEmail(cellData.value, 'text/html')}><b>Show html email</b></a>&nbsp;<br />
+                      </span>
+                  }
                 </div>
               )
             }

--- a/src/ui/mails/Mails.js
+++ b/src/ui/mails/Mails.js
@@ -83,19 +83,21 @@ class Mails extends React.Component {
   }
 
   render() {
-    const setCurrentEmail = email => {
+    const setCurrentEmail = (email, type) => {
       this.state.currentEmail = email;
+      this.state.type = type;
       this.forceUpdate();
     };
 
     const hide = () => {
       this.state.currentEmail = null;
+      this.state.type = null;
       this.forceUpdate();
     };
 
     const data = this.state.mails;
     const currentEmail = this.state.currentEmail;
-
+    const selectedEmailType = this.state.type;
 
     return <div>
       <div style={{ textAlign: 'right' }}>
@@ -110,7 +112,7 @@ class Mails extends React.Component {
         <a href='#' onClick={this.refresh}>Refresh</a>
       </div>
 
-      {currentEmail ? <PopUp currentEmail={currentEmail} hide={hide} /> : null}
+      {currentEmail ? <PopUp currentEmail={currentEmail} hide={hide} selectedEmailType={selectedEmailType} /> : null}
 
       <ReactTable
         style={{ marginTop: '12px' }}
@@ -169,7 +171,8 @@ class Mails extends React.Component {
               accessor: mail => mail,
               Cell: cellData => (
                 <div>
-                  <a onClick={() => setCurrentEmail(cellData.value)}><b>Show email</b></a>&nbsp;<br />
+                  <a onClick={() => setCurrentEmail(cellData.value, 'text/plain')}><b>Show plain text email</b></a>&nbsp;|&nbsp;
+                  <a onClick={() => setCurrentEmail(cellData.value, 'text/html')}><b>Show html email</b></a>&nbsp;<br />
                 </div>
               )
             }

--- a/src/ui/mails/PopUp.js
+++ b/src/ui/mails/PopUp.js
@@ -5,6 +5,7 @@ const SimpleContent = (content) => {
 };
 
 const HtmlContent = (content, mailContext) => {
+
   const attachments = mailContext.attachments || [];
 
   const contentWithAttachedAttachments = attachments
@@ -61,8 +62,6 @@ const TemplateContent = (templateId, personalizations) => {
 };
 
 const PopUp = (props) => {
-
-  console.log(props);
 
   const contentRenderer = {
     'text/plain': SimpleContent,

--- a/src/ui/mails/PopUp.js
+++ b/src/ui/mails/PopUp.js
@@ -5,7 +5,6 @@ const SimpleContent = (content) => {
 };
 
 const HtmlContent = (content, mailContext) => {
-
   const attachments = mailContext.attachments || [];
 
   const contentWithAttachedAttachments = attachments
@@ -63,6 +62,8 @@ const TemplateContent = (templateId, personalizations) => {
 
 const PopUp = (props) => {
 
+  console.log(props);
+
   const contentRenderer = {
     'text/plain': SimpleContent,
     'text/html': HtmlContent,
@@ -90,11 +91,11 @@ const PopUp = (props) => {
     }
   };
 
-  const renderDisplayContent = (displayContent) => {
+  const renderDisplayContent = (displayContent, selectedEmailType) => {
     if (Array.isArray(displayContent)) {
       return (
         <div>
-          {displayContent.map((content, index) => (
+          {displayContent.filter(content => content.type === selectedEmailType).map((content, index) => (
             <div key={index}>
               {
                 renderContent(
@@ -123,7 +124,7 @@ const PopUp = (props) => {
             props.currentEmail.template_id,
             props.currentEmail.personalizations
           ) :
-          renderDisplayContent(props.currentEmail.displayContent)
+          renderDisplayContent(props.currentEmail.displayContent, props.selectedEmailType)
         }
 
       </div>


### PR DESCRIPTION
We found it strange in the new version that the whole plain-text email is shown first (as for us it contains gibber). 

This now shows either the Sendgrid template button or the Html version and Text Plain version buttons.