### PR TITLE
Smaller docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,44 @@
-FROM node:14.15.4-alpine
+FROM node:14.15.4-alpine as node
+
+# Build stage
+FROM node AS builder
 LABEL author="Siyavash Habashi (ghashange) / Ronald Dehuysser (Bringme)"
 
-# adds the packages certbot and tini, make and g++ (make and g++ needed for nmp ci)
-RUN apk add --no-cache certbot tini make g++
+ENV DOCKER_BUILD="true"
+
+# the directory for your app within the docker image
+# NOTE: if you need to change this, change the $CERT_WEBROOT_PATH env
+WORKDIR /app
+
+######################################################################################
+# Add your own Dockerfile entries here
+######################################################################################
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+
+FROM node
+# Update the system
+RUN apk --no-cache -U upgrade
+# adds the packages certbot and tini
+RUN apk add --no-cache certbot tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
 # copy and chmod the shell script which will initiate the webroot
 COPY letsencrypt_webroot.sh /
 RUN chmod +x /letsencrypt_webroot.sh
+
+WORKDIR /usr/src/server
+# Copy package.json and package-lock.json
+COPY package*.json ./
+# Install only production dependencies
+RUN npm i --only=production
+# Copy transpiled js from builder stage into the final image
+COPY --from=builder /app/dist ./dist
+# Copy src/server into final image 
+COPY src/server ./src/server
 
 # port 80 is mandatory for webroot challenge
 # port 443 is mandatory for https
@@ -16,22 +47,10 @@ EXPOSE 80
 EXPOSE 443
 EXPOSE 3000
 
-ENV DOCKER_BUILD="true"
+# Set all environment variables
+ENV DOCKER_BUILD="false"
+ENV NODE_ENV=production
 ENV API_KEY=sendgrid-api-key
 
-# the directory for your app within the docker image
-# NOTE: if you need to change this, change the $CERT_WEBROOT_PATH env
-WORKDIR /usr/src/server
-
-######################################################################################
-# Add your own Dockerfile entries here
-######################################################################################
-ADD src src/
-ADD package*.json ./
-RUN npm ci
-RUN npm run build
-
-
-# the command which starts your express server. Rename 'index.js' to the appropriate filename
-ENV DOCKER_BUILD="false"
-CMD ["npm", "run", "server-run"]
+# the command which starts your express server.
+CMD ["node", "./src/server/Server.js"]

--- a/letsencrypt_webroot.sh
+++ b/letsencrypt_webroot.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # If the following environment variables are set, certbot will try to generate a new SSL certificate for your domain.
 # A certificate renewal chronjob will also be created.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sendgrid-mock",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sendgrid-mock",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@appsaloon/auto-ssl": "^1.0.8",


### PR DESCRIPTION
One more PR to decrease the image size of the docker container.

Original size: 559 MB
New size: 212 MB.

We had some SSL issues and the reduced size also seems to help with that.