### PR TITLE
Allow to filter UI via URI

### DIFF
--- a/src/ui/mails/Mails.js
+++ b/src/ui/mails/Mails.js
@@ -13,6 +13,7 @@ class Mails extends React.Component {
       currentEmail: null,
       subject: queryParams.get('subject') || '',
       to: queryParams.get('to') || '',
+      dateTimeSince: queryParams.get('dateTimeSince') || '',
     };
 
     this.lastQuery = '';
@@ -55,6 +56,10 @@ class Mails extends React.Component {
     if (this.state.subject.length > 3) {
       apiParams.set('subject', `%${this.state.subject}%`);
     }
+    if(this.state.dateTimeSince.length > 4) {
+      apiParams.set('dateTimeSince', `${this.state.dateTimeSince}`);
+    }
+
 
     if (apiParams.toString() == this.lastQuery) return;
 


### PR DESCRIPTION
For some automated test we really want to make sure that a button is available and visible in the mail.

That's why we're using Selenium for this usec-case and using Selenium, we visit sendgrid-mock, find the relevant mail and click on the button. 

To make sure we've got the right mail, we would also like to add a dateTimeSince (again in the URI) but this time for the UI instead of the API. This PR adds that functionality.