### PR TITLE
Added gitattributes to fix line-endings in letsencrypt_webroot.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+letsencrypt_webroot.sh text eol=lf


### PR DESCRIPTION
Hi,

Since a while I was hoping to use your docker image directly instead of the images I built on my machine.

But, for some strange issue the image I built was working perfectly but yours not (the letsencrypt stuff). Today, we did a deep dive and found out that this is probably because you are working on Windows and the `letsencrypt_webroot.sh` file has CR-LF endings which causes problems in shell scripts.

See also:
- https://essenceofcode.com/2019/11/20/linux-style-line-feeds-in-docker-desktop-on-windows/
- https://stackoverflow.com/questions/30037627/syntax-error-fi-unexpected-expecting-then-in-bash-script/30038045

To fix this, we added a `.gitattributes` file which forces the CR-LF in that file (which come from Windows) to be LF (so to be compatible with the docker image).

If you merge this PR, can you make sure (using VSCode or Notepad++) that the line endings for the `letsencrypt_webroot.sh` file are only LF?

Thx!