### PR TITLE
Add sleep time for DNS in azure to be available.

### DIFF
--- a/letsencrypt_webroot.sh
+++ b/letsencrypt_webroot.sh
@@ -5,6 +5,7 @@
 if [ $CERT_DOMAINNAMES ] && [ $CERT_EMAIL ]; then
 
     # Wait for DNS to be mapped to IP and docker container to be fully started
+    echo "Waiting for DNS to be mapped ..."
     sleep 60
     # Generate the initial letsencrypt / certbot SSL certificate using the webroot method.
     # This method will send a challenge to this server's http port 80.

--- a/letsencrypt_webroot.sh
+++ b/letsencrypt_webroot.sh
@@ -4,6 +4,8 @@
 # A certificate renewal chronjob will also be created.
 if [ $CERT_DOMAINNAMES ] && [ $CERT_EMAIL ]; then
 
+    # Wait for DNS to be mapped to IP and docker container to be fully started
+    sleep 60
     # Generate the initial letsencrypt / certbot SSL certificate using the webroot method.
     # This method will send a challenge to this server's http port 80.
     # If the response is valid, certbot will put the generated SSL certificates in the following directory: /etc/letsencrypt/live/$SUBDOMAIN.$DOMAIN/


### PR DESCRIPTION
Hi,

one more PR - when stopping/starting/restarting/... we saw that the let's encrypt sometimes is too fast (before the Azure DNS is ready). By adding some sleep, this appears to be resolved.

Thx again!