### PR TITLE
fix: change port to 3050 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export DOCKER_BUILDKIT=1
+sha=$(git rev-parse --short HEAD)
+echo $sha
+docker build -t asia.gcr.io/persuit-core/sendgrid-mock:$sha .
+docker push asia.gcr.io/persuit-core/sendgrid-mock:$sha

--- a/src/server/ExpressApp.js
+++ b/src/server/ExpressApp.js
@@ -96,6 +96,10 @@ const setupExpressApp = (
   });
   
   app.use(express.static(path.join(__dirname, '../../dist')));
+  app.get('/sendgridmock', function (req, res) {
+    res.sendFile(path.join(__dirname, '../../dist', 'index.html'));
+  });
+
   app.get('/', function (req, res) {
     res.sendFile(path.join(__dirname, '../../dist', 'index.html'));
   });

--- a/src/server/Server.js
+++ b/src/server/Server.js
@@ -55,7 +55,7 @@ if (enableSsl) {
   asHttpsServer(app, sslRateLimitConfiguration);
 } else {
 
-  const serverPort = 3000;
+  const serverPort = 3050;
   app.listen(serverPort);
 
   logger.info(`Started sendgrid-mock on port ${serverPort}!`);


### PR DESCRIPTION
moving port from `3000` to `3050` which seems to cause conflicts from time to time with persuit0web. 

docker run -p 3050:3050 asia.gcr.io/persuit-core/sendgrid-mock:3783064