### PR TITLE
Updated basic auth to no longer apply to API endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ SendGrid-Mock serves as a simple server mocking the sendgrid-apis for developmen
 
 ### Extras
 
-* Basic authentication support: Add basic authentication credentials by specifying environment variable `AUTHENTICATION` to the following format: `user1:passwordForUser1;user2:passwordForUser2`
+* Basic authentication support: Add basic authentication credentials by specifying environment variable `AUTHENTICATION` to the following format: `user1:passwordForUser1;user2:passwordForUser2`. This applies only to the static content.
+
+* API key support: Add API key authentication by specifying environment variable `API_KEY`. This applies only to the API endpoints.
 
 * Request rate limiting: Both the actual SendGrid API server as well as the SSL server can be rate limited by specifying environment variables:
   * `RATE_LIMIT_ENABLED`: `true` or `false` (default)

--- a/src/server/ExpressApp.js
+++ b/src/server/ExpressApp.js
@@ -16,26 +16,21 @@ const setupExpressApp = (
 
   const app = express();
 
-  if (apiAuthentication.enabled) {
-
-    app.use(basicAuth({ challenge: true, users: apiAuthentication.users }));
-  }
-
   if (rateLimitConfiguration.enabled) {
-  
+
     const rateLimitWindowInMs = rateLimitConfiguration.windowInMs;
     const rateLimitMaxRequests = rateLimitConfiguration.maxRequests;
-  
+
     logger.info(`Rate limit enabled with ${rateLimitMaxRequests} requests per ${rateLimitWindowInMs} ms.`);
-  
+
     const definedRateLimit = rateLimit({
       windowMs: rateLimitWindowInMs,
       max: rateLimitMaxRequests,
       standardHeaders: true,
     });
-  
+
     app.use(definedRateLimit);  
-  
+
   } else {
     logger.warn('Rate limit is disabled!');
   }
@@ -43,12 +38,17 @@ const setupExpressApp = (
   // Request handler for non-static requests.
   RequestHandler(app, mockedApiAuthenticationKey, mailHandler);
 
+  // We configure this middleware after the API request handlers because we want basic auth to only apply to the static content.
+  if (apiAuthentication.enabled) {
+    app.use(basicAuth({ challenge: true, users: apiAuthentication.users }));
+  }
+
   // Static content.
   app.use(express.static(path.join(__dirname, '../../dist')));
   app.get('/', function (req, res) {
     res.sendFile(path.join(__dirname, '../../dist', 'index.html'));
   });
-  
+
   return app;
 };
 

--- a/test/server/ExpressApp.test.js
+++ b/test/server/ExpressApp.test.js
@@ -132,6 +132,24 @@ describe('App', () => {
       expect(response.statusCode).toBe(202);        
     });
 
+    test('basic auth does not apply to api endpoints', async () => {
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+
+      const sut = setupExpressApp(
+          mailHandlerStub, 
+          {enabled: true, users: {shadow: 'the password'}},
+          'sonic',
+          rateLimitConfiguration
+        );
+    
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(testMail)
+        .set('Authorization', 'Bearer sonic')
+
+      expect(response.statusCode).toBe(202);
+    });
+
     test('accepts name as null', async () => {
       const mailWithNameNull = {
         ...testMail,
@@ -247,33 +265,25 @@ describe('App', () => {
     });
 
     describe('when authentication enabled', () => {
-
-      test('blocks not authenticated user ', async () => {
-
-        const mailHandlerStub = sinon.createStubInstance(MailHandler);
-
-        const sut = setupExpressApp(mailHandlerStub, {enabled: true}, undefined, rateLimitConfiguration);
-  
-        const response = await request(sut).get('/api/mails');
-        expect(response.statusCode).toBe(401);        
-      });
-
-      test('pass through authenticated user ', async () => {
-
+      test('basic auth does not apply to api endpoints', async () => {
         const mailHandlerStub = sinon.createStubInstance(MailHandler);
 
         const sut = setupExpressApp(
-          mailHandlerStub, 
-          {enabled: true, users: {sonic: 'the password'}},
-          undefined,
-          rateLimitConfiguration,
-        );
-  
+            mailHandlerStub,
+            {enabled: true, users: {sonic: 'the password'}},
+            undefined,
+            rateLimitConfiguration
+          );
+
         const response = await request(sut)
           .get('/api/mails')
-          .auth('sonic', 'the password');
+          .auth('shadow', 'not the password');
 
-        expect(response.statusCode).toBe(200);        
+        const responseNoAuth = await request(sut)
+          .get('/api/mails');
+
+        expect(response.statusCode).toBe(200);
+        expect(responseNoAuth.statusCode).toBe(200);
       });
     });
   });
@@ -313,33 +323,25 @@ describe('App', () => {
     });
 
     describe('when authentication enabled', () => {
-
-      test('blocks not authenticated user ', async () => {
-
-        const mailHandlerStub = sinon.createStubInstance(MailHandler);
-
-        const sut = setupExpressApp(mailHandlerStub, {enabled: true}, undefined, rateLimitConfiguration);
-  
-        const response = await request(sut).delete('/api/mails');
-        expect(response.statusCode).toBe(401);        
-      });
-
-      test('pass through authenticated user ', async () => {
-
+      test('basic auth does not apply to api endpoints', async () => {
         const mailHandlerStub = sinon.createStubInstance(MailHandler);
 
         const sut = setupExpressApp(
-          mailHandlerStub, 
-          {enabled: true, users: {sonic: 'the password'}},
-          undefined,
-          rateLimitConfiguration,
-        );
-  
+            mailHandlerStub,
+            {enabled: true, users: {sonic: 'the password'}},
+            undefined,
+            rateLimitConfiguration
+          );
+
         const response = await request(sut)
           .delete('/api/mails')
-          .auth('sonic', 'the password');
+          .auth('shadow', 'not the password');
 
-        expect(response.statusCode).toBe(202);        
+        const responseNoAuth = await request(sut)
+          .delete('/api/mails');
+
+        expect(response.statusCode).toBe(202);
+        expect(responseNoAuth.statusCode).toBe(202);
       });
     });
   });


### PR DESCRIPTION
Closes #80 
Updated the order middleware is added in to not apply basic auth to the API endpoints.
Updated tests to reflect the new state of auth on the endpoints.
Updated README to include section about API key auth and updated the basic auth section to be more specific about what it applies to.