### PR TITLE
Events: Add Category and Custom Arg Support

### DIFF
--- a/src/server/RequestHandler.js
+++ b/src/server/RequestHandler.js
@@ -68,6 +68,13 @@ const jsonSchema = {
         type: 'string',
         nullable: true,
       },
+      categories: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        nullable: true,
+      }
     }
   }
 };

--- a/src/server/RequestHandler.js
+++ b/src/server/RequestHandler.js
@@ -57,6 +57,10 @@ const jsonSchema = {
                   },
                 },
               },
+            },
+            custom_args: {
+              type: 'object',
+              nullable: true,
             }
           },
         }
@@ -73,6 +77,10 @@ const jsonSchema = {
         items: {
           type: 'string',
         },
+        nullable: true,
+      },
+      custom_args: {
+        type: 'object',
         nullable: true,
       }
     }

--- a/src/server/handler/MailHandler.js
+++ b/src/server/handler/MailHandler.js
@@ -147,12 +147,14 @@ class MailHandler {
     const deliveredEvents = mail.personalizations
       .flatMap(personalization => personalization.to)
       .map(to => {
+        const categories = mail.categories ? mail.categories : [];
         let event = {
           email: to.email,
           timestamp: datetime.getTime(),
           event: 'delivered',
           sg_event_id: crypto.randomUUID(),
           sg_message_id: messageId,
+          category: categories
         };
         event['smtp-id'] = crypto.randomUUID();
         return event;

--- a/test/server/ExpressApp.test.js
+++ b/test/server/ExpressApp.test.js
@@ -209,6 +209,59 @@ describe('App', () => {
   
       expect(response.statusCode).toBe(400); 
     });
+
+    test('accepts categories as null', async () => {
+      const mailWithCategoriesNull = {
+        ...testMail,
+        'categories': null
+      };
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithCategoriesNull)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(202);
+    });
+
+    test('accepts categories as array', async () => {
+      const mailWithCategoriesArray = {
+        ...testMail,
+        'categories': ['category1', 'category2']
+      };
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithCategoriesArray)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(202);
+    });
+
+    test('rejects categories of incorrect type', async () => {
+      const mailWithInvalidCategories = {
+        ...testMail,
+        'categories': {
+          'bad': 'data'
+        }
+      };
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithInvalidCategories)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(400);
+    });
   
   });
 

--- a/test/server/ExpressApp.test.js
+++ b/test/server/ExpressApp.test.js
@@ -262,7 +262,110 @@ describe('App', () => {
 
       expect(response.statusCode).toBe(400);
     });
-  
+
+    test('accepts custom args as an object', async () => {
+      const mailWithCustomArgs = {
+        ...testMail,
+        'custom_args': {
+          'key': 'value'
+        }
+      };
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithCustomArgs)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(202);
+    });
+
+    test('rejects custom args of incorrect type', async () => {
+      const mailWithInvalidCustomArgs = {
+        ...testMail,
+        'custom_args': ['invalid']
+      };
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithInvalidCustomArgs)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    test('accepts custom args as null', async () => {
+      const mailWithCustomArgsNull = {
+        ...testMail,
+        'custom_args': null
+      };
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithCustomArgsNull)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(202);
+    });
+
+    test('accepts custom args at the personalization level', async () => {
+      const personalizedCustomArgs = {
+        'key': 'value'
+      };
+
+      const mailWithPersonalizedCustomArgs = testMail;
+      mailWithPersonalizedCustomArgs.personalizations[0]['custom_args'] = personalizedCustomArgs;
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithPersonalizedCustomArgs)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(202);
+    });
+
+    test('rejects custom args at the personalization level of incorrect type', async () => {
+      const personalizedCustomArgs = ['invalid'];
+
+      const mailWithInvalidPersonalizedCustomArgs = testMail;
+      mailWithInvalidPersonalizedCustomArgs.personalizations[0]['custom_args'] = personalizedCustomArgs;
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithInvalidPersonalizedCustomArgs)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    test('accepts custom args at the personalization level as null', async () => {
+      const mailWithPersonalizedCustomArgsNull = testMail;
+      mailWithPersonalizedCustomArgsNull.personalizations[0]['custom_args'] = null;
+
+      const mailHandlerStub = sinon.createStubInstance(MailHandler);
+      const sut = setupExpressApp(mailHandlerStub, { enabled: false }, 'sonic', rateLimitConfiguration);
+
+      const response = await request(sut)
+        .post('/v3/mail/send')
+        .send(mailWithPersonalizedCustomArgsNull)
+        .set('Authorization', 'Bearer sonic');
+
+      expect(response.statusCode).toBe(202);
+    });
   });
 
   describe('GET /api/mails', () => {

--- a/test/server/handler/MailHandler.test.js
+++ b/test/server/handler/MailHandler.test.js
@@ -27,6 +27,7 @@ const testMail = {
       'value': 'important content',
     },
   ],
+  'categories': ['important']
 };
 
 describe('MailHandler', () => {
@@ -57,55 +58,6 @@ describe('MailHandler', () => {
       const addedMails = sut.getMails();
 
       expect(addedMails.length).toBe(3);
-    });
-
-    describe('add mail when EVENT_DELIVERY_URL is set', () => {
-
-      beforeAll(() => {
-        process.env.EVENT_DELIVERY_URL = 'http://example.com';
-      });
-
-      test('send delivery events', () => {
-        const sut = new MailHandler();
-
-        axios.post.mockResolvedValue({data: {message: 'success'}});
-
-        const messageId = crypto.randomUUID();
-
-        sut.addMail(testMail, messageId);
-
-        expect(axios.post.mock.calls[0][0]).toEqual(process.env.EVENT_DELIVERY_URL);
-        const eventData = axios.post.mock.calls[0][1];
-        expect(eventData.length).toBe(2);
-        expect(eventData[0]).toMatchObject({
-          email: testMail.personalizations[0].to[0].email,
-          event: 'delivered',
-          timestamp: expect.any(Number),
-          sg_event_id: expect.any(String),
-          sg_message_id: messageId,
-          'smtp-id': expect.any(String),
-        });
-      });
-
-      test('send delivery events with defaulted messageId', () => {
-        const sut = new MailHandler();
-
-        axios.post.mockResolvedValue({data: {message: 'success'}});
-
-        sut.addMail(testMail);
-
-        expect(axios.post.mock.calls[0][0]).toEqual(process.env.EVENT_DELIVERY_URL);
-        const eventData = axios.post.mock.calls[0][1];
-        expect(eventData.length).toBe(2);
-        expect(eventData[0]).toMatchObject({
-          email: testMail.personalizations[0].to[0].email,
-          event: 'delivered',
-          timestamp: expect.any(Number),
-          sg_event_id: expect.any(String),
-          sg_message_id: expect.any(String),
-          'smtp-id': expect.any(String),
-        });
-      });
     });
 
     describe('delete old mails', () => {
@@ -457,6 +409,94 @@ describe('MailHandler', () => {
       expect(remainingMails).toStrictEqual([
         {...testMail, datetime: addedMailDateTime},
       ]);
+    });
+  });
+
+  describe('delivery events', () => {
+    describe('add mail sends when EVENT_DELIVERY_URL is set', () => {
+
+      beforeAll(() => {
+        process.env.EVENT_DELIVERY_URL = 'http://example.com';
+      });
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      test('send delivery events', () => {
+        const sut = new MailHandler();
+
+        axios.post.mockResolvedValue({data: {message: 'success'}});
+
+        const messageId = crypto.randomUUID();
+
+        sut.addMail(testMail, messageId);
+
+        expect(axios.post.mock.calls[0][0]).toEqual(process.env.EVENT_DELIVERY_URL);
+        const eventData = axios.post.mock.calls[0][1];
+        expect(eventData.length).toBe(2);
+        expect(eventData[0]).toMatchObject({
+          email: testMail.personalizations[0].to[0].email,
+          event: 'delivered',
+          timestamp: expect.any(Number),
+          sg_event_id: expect.any(String),
+          sg_message_id: messageId,
+          'smtp-id': expect.any(String),
+          category: expect.any(Array)
+        });
+      });
+
+      test('send delivery events with defaulted messageId', () => {
+        const sut = new MailHandler();
+
+        axios.post.mockResolvedValue({data: {message: 'success'}});
+
+        sut.addMail(testMail);
+
+        expect(axios.post.mock.calls[0][0]).toEqual(process.env.EVENT_DELIVERY_URL);
+        const eventData = axios.post.mock.calls[0][1];
+        expect(eventData.length).toBe(2);
+        expect(eventData[0]).toMatchObject({
+          sg_message_id: expect.any(String),
+        });
+      });
+
+      describe('send delivery events with categories', () => {
+
+        test('single category array is returned as an array', () => {
+          const sut = new MailHandler();
+
+          axios.post.mockResolvedValue({data: {message: 'success'}});
+
+          sut.addMail(testMail);
+
+          expect(axios.post.mock.calls[0][0]).toEqual(process.env.EVENT_DELIVERY_URL);
+          const eventData = axios.post.mock.calls[0][1];
+          expect(eventData.length).toBe(2);
+          expect(eventData[0]).toMatchObject({
+            category: ['important']
+          });
+        });
+
+        test('without categories returns empty array', () => {
+          const mailWithoutCategories = {
+            ...testMail,
+          };
+          delete mailWithoutCategories.categories;
+          const sut = new MailHandler();
+
+          axios.post.mockResolvedValue({data: {message: 'success'}});
+
+          sut.addMail(mailWithoutCategories);
+
+          expect(axios.post.mock.calls[0][0]).toEqual(process.env.EVENT_DELIVERY_URL);
+          const eventData = axios.post.mock.calls[0][1];
+          expect(eventData.length).toBe(2);
+          expect(eventData[0]).toMatchObject({
+            category: [],
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
# Context
#78 previously added support for basic `delivered` events, but did not include commonly used properties such as `category` and `custom_args`. This PR adds support for:
* applying the `category` from the send `categories`
* applying `custom_args` from the send request at the root level
* applying `custom_args` from the send request at the `personalization` level

# Changes
* Updated the JSON schema to allow and validate `categories` for `/v3/mail/send`.
* Updated the JSON schema to allow and validate `custom_args` at the root level.
* Updated the JSON schema to allow and validate `custom_args` at the `personalization` level.
* Updated the `MailHandler.sendDeliveryEvents` function to apply these properties to events.

# Testing
Use the following Python script to start a mini server to receive events:
```python
import http.server
import socketserver

class MyHandler(http.server.SimpleHTTPRequestHandler):
    def do_POST(self):
        content_length = int(self.headers['Content-Length'])
        post_data = self.rfile.read(content_length)
        print(f'post_data: {post_data}')

        self.send_response(200)
        self.send_header('Content-type', 'text/plain')
        self.end_headers()

        response = b'POST request received:\n' + post_data
        self.wfile.write(response)

PORT = 8080

with socketserver.TCPServer(("", PORT), MyHandler) as httpd:
    print(f"Serving at port {PORT}")
    httpd.serve_forever()
```
Start the application with the `EVENT_DELIVERY_URL` set: 
    ```shell
    API_KEY=sendgrid-api-key EVENT_DELIVERY_URL=http://localhost:8080 npm run dev
    ```

## Categories
1. Send a request that does not include `categories`:
    ```shell
    curl --request POST \
      --url http://localhost:3000/v3/mail/send \
      --header 'Authorization: Bearer sendgrid-api-key' \
      --header 'Content-Type: application/json' \
      --header 'User-Agent: insomnia/9.3.2' \
      --data '{
      "personalizations": [
        {
          "to": [{
            "email": "to@example.com"
          }, {
            "email": "to2@example.com"
          }]
        }
      ],
      "from": {
        "email": "from@example.com"
      },
    	"subject": "Some subject",
    	"content": [
        {
          "type": "text/plain",
          "value": "important content"
        }
      ],
      "template_id": "test-template-id"
    }
    '
    ```
2. ✅ Validate that an event with a `"category": []` property is received.
3. Send the same event with a `"categories": ["first", "second"]` property.
4. ✅ Validate that an event with a `"category": ["first", "second"]` property is received.

## Custom Args
1. Send a request that includes custom args at the root level as well as at the personalization level:
    ```shell
    curl --request POST \
      --url http://localhost:3000/v3/mail/send \
      --header 'Authorization: Bearer sendgrid-api-key' \
      --header 'Content-Type: application/json' \
      --header 'User-Agent: insomnia/9.3.2' \
      --data '{
      "personalizations": [
        {
          "to": [{
            "email": "to@example.com"
          }, {
            "email": "to2@example.com"
          }],
    			"custom_args": {
    				"key1": "value2",
    				"key2": "something else",
    				"key with spaces": "spaces work"
    			}
        }
      ],
      "from": {
        "email": "from@example.com"
      },
    	"subject": "Some subject",
    	"content": [
        {
          "type": "text/plain",
          "value": "important content"
        }
      ],
      "template_id": "test-template-id",
    	"categories": ["pets", "animals"],
    	"custom_args": {
    		"key1": "value1",
    		"key3": "from mail",
    		"smtp-id": "234234"
    	}
    }
    '
    ```
2. ✅ Validate that each event contains the `key3` property.
3. ✅ Reserved keys: validate that the `smtp-id` is *not* the key specified in the root level `custom_args`. This is a generated value.
4. ✅ Validate that each event contains `key1`, `key2`, `key with spaces` with values taken from the `personalization`.
5. ✅ Validate that `v3/mail/send` requests can continue to be made without `custom_args` at either the root or personalization levels.