### PR TITLE
Add support for building Docker image for both x64 and ARM64 platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-22.04-arm
     steps:
       - name: Prepare
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,5 +30,11 @@ jobs:
     needs:
       - test
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64, linux/arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,15 +26,40 @@ jobs:
         run: npm run test
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs:
       - test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm64
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghashange/sendgrid-mock
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push Docker image
+
+      - name: Build
+        id: build
         uses: docker/build-push-action@v4
         with:
-          platforms: linux/amd64, linux/arm64
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,push=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,20 +7,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  prepare-release:
     if: |
       (github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'master') ||
       github.actor == 'janjaali'
     runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Get version
+        id: get_version
         run: |
           VERSION=$(cat ./version)
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - uses: bbonkr/git-tag-check-action@v1.0.18
         id: validateTag
@@ -41,19 +45,102 @@ jobs:
           create_annotated_tag: true
           tag_prefix: v
 
+  build:
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - prepare-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghashange/sendgrid-mock
+
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push Docker images
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v4
         with:
-          push: true
-          tags: ghashange/sendgrid-mock:${{ env.RELEASE_VERSION }}
-          platforms: linux/amd64, linux/arm64
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=ghashange/sendgrid-mock,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-release
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghashange/sendgrid-mock
+          tags: |
+            type=raw,value=${{ needs.prepare-release.outputs.release_version }}
+            type=raw,value=latest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghashange/sendgrid-mock@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghashange/sendgrid-mock:${{ needs.prepare-release.outputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push Docker images
         uses: docker/build-push-action@v4
         with:
           push: true
           tags: ghashange/sendgrid-mock:${{ env.RELEASE_VERSION }}
+          platforms: linux/amd64, linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-22.04-arm
     steps:
       - name: Prepare
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV DOCKER_BUILD="true"
 # NOTE: if you need to change this, change the $CERT_WEBROOT_PATH env
 WORKDIR /app
 
+RUN apk add --no-cache python3 make g++
+
 ######################################################################################
 # Add your own Dockerfile entries here
 ######################################################################################
@@ -23,7 +25,7 @@ FROM node
 # Update the system
 RUN apk --no-cache -U upgrade
 # adds the packages certbot and tini
-RUN apk add --no-cache certbot tini
+RUN apk add --no-cache certbot tini python3 make g++
 ENTRYPOINT ["/sbin/tini", "--"]
 
 # copy and chmod the shell script which will initiate the webroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM node
 # Update the system
 RUN apk --no-cache -U upgrade
 # adds the packages certbot and tini
-RUN apk add --no-cache certbot tini python3 make g++
+RUN apk add --no-cache certbot tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
 # copy and chmod the shell script which will initiate the webroot


### PR DESCRIPTION
Motivation
----------

Currently, this Docker container is only built for x64 architectures. This causes issues on systems that use ARM64 architectures like Apple Silicon.

Docker has had a facility for creating multiplatform images for a while now (via buildx) and the Github docker build action already supports this capability. This PR updates the Github action to specify the platform types to build a multiplatform Docker image.

Modifications
-------------

In both the build and release workflows, I added the 'platform' attribute to the docker build action. The value of the attribute is a comma-separated list of the supported architectures (linux/amd64 for x64 and linux/arm64 for ARM64). This required adding the QEMU and Docker buildx actions to work.

Result
------

The result is the sendgrid mock Docker container will now be built for both x64 and ARM64 platforms.